### PR TITLE
Add query history page

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
         { path: '/', label: 'Dashboard', icon: 'lucide:layout-dashboard' },
         { path: '/documents', label: 'Documentos', icon: 'lucide:file-text' },
         { path: '/query', label: 'Consulta', icon: 'lucide:search' },
+        { path: '/query/history', label: 'Historial', icon: 'lucide:history' },
         { path: '/settings', label: 'Ajustes', icon: 'lucide:settings' },
     ];
 

--- a/src/pages/QueryHistory.tsx
+++ b/src/pages/QueryHistory.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+    Button,
+    Input,
+    Table,
+    TableHeader,
+    TableColumn,
+    TableBody,
+    TableRow,
+    TableCell,
+    Card,
+    CardBody,
+    Spinner
+} from '@heroui/react';
+import { Icon } from '@iconify/react';
+import { QueryResult } from '../types';
+
+const QueryHistory: React.FC = () => {
+    const navigate = useNavigate();
+    const [history, setHistory] = React.useState<QueryResult[]>([]);
+    const [search, setSearch] = React.useState<string>('');
+    const [isLoading, setIsLoading] = React.useState<boolean>(true);
+
+    React.useEffect(() => {
+        try {
+            const stored = localStorage.getItem('ragQueryHistory');
+            const data: QueryResult[] = stored ? JSON.parse(stored) : [];
+            setHistory(data);
+        } catch (e) {
+            console.warn('No se pudo cargar el historial de consultas:', e);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const filtered = history.filter(q =>
+        q.question.toLowerCase().includes(search.toLowerCase()) ||
+        q.answer.toLowerCase().includes(search.toLowerCase())
+    );
+
+    const formatDate = (dateString: string) => {
+        const date = new Date(dateString);
+        return new Intl.DateTimeFormat('es-ES', {
+            day: '2-digit',
+            month: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit'
+        }).format(date);
+    };
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center items-center h-64">
+                <Spinner size="lg" color="primary" />
+            </div>
+        );
+    }
+
+    if (history.length === 0) {
+        return (
+            <Card>
+                <CardBody className="flex flex-col items-center justify-center py-8">
+                    <Icon icon="lucide:history" className="text-default-500 mb-4" width={48} height={48} />
+                    <p className="text-default-500 text-center mb-4">Aún no hay consultas almacenadas</p>
+                    <Button color="primary" onPress={() => navigate('/query')}>
+                        Realizar consulta
+                    </Button>
+                </CardBody>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="max-w-5xl mx-auto">
+            <div className="flex justify-between items-center mb-6">
+                <h1 className="text-2xl font-bold">Historial de Consultas</h1>
+                <Button color="primary" onPress={() => navigate('/query')} startContent={<Icon icon="lucide:search" width={18} />}>Nueva Consulta</Button>
+            </div>
+            <Input
+                className="mb-4"
+                placeholder="Buscar consultas..."
+                value={search}
+                onValueChange={setSearch}
+                startContent={<Icon icon="lucide:search" width={16} />}
+            />
+            <Table aria-label="Historial de consultas" removeWrapper classNames={{ base: 'min-h-[400px]' }}>
+                <TableHeader>
+                    <TableColumn>PREGUNTA</TableColumn>
+                    <TableColumn>FECHA</TableColumn>
+                    <TableColumn>ACCIONES</TableColumn>
+                </TableHeader>
+                <TableBody>
+                    {filtered.map((q) => (
+                        <TableRow key={q.id}>
+                            <TableCell className="max-w-xs truncate whitespace-pre-wrap">{q.question}</TableCell>
+                            <TableCell>{formatDate(q.timestamp)}</TableCell>
+                            <TableCell>
+                                <Button
+                                    as={Link}
+                                    to={`/query/results?id=${q.id}&q=${encodeURIComponent(q.question)}`}
+                                    size="sm"
+                                    variant="light"
+                                    color="primary"
+                                    startContent={<Icon icon="lucide:eye" width={16} />}
+                                >
+                                    Ver
+                                </Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    );
+};
+
+export default QueryHistory;

--- a/src/pages/QueryResults.tsx
+++ b/src/pages/QueryResults.tsx
@@ -70,6 +70,17 @@ const QueryResults: React.FC = () => {
                 };
 
                 setResult(mockResult);
+
+                // Guardar en historial (localStorage)
+                try {
+                    const stored = localStorage.getItem('ragQueryHistory');
+                    const history: QueryResult[] = stored ? JSON.parse(stored) : [];
+                    history.unshift(mockResult);
+                    // Limitar a los últimos 50 registros
+                    localStorage.setItem('ragQueryHistory', JSON.stringify(history.slice(0, 50)));
+                } catch (e) {
+                    console.warn('No se pudo guardar el historial de consultas:', e);
+                }
             } catch (error) {
                 console.error('Error al cargar resultados:', error);
                 addToast({

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -8,6 +8,7 @@ import EditDocument from '../pages/EditDocument';
 import DocumentDetails from '../pages/DocumentDetails';
 import QueryPage from '../pages/QueryPage';
 import QueryResults from '../pages/QueryResults';
+import QueryHistory from '../pages/QueryHistory';
 import Settings from '../pages/Settings';
 import NotFound from '../pages/NotFound';
 
@@ -22,6 +23,7 @@ const AppRouter: React.FC = () => {
                 <Route path="documents/:id" element={<DocumentDetails />} />
                 <Route path="query" element={<QueryPage />} />
                 <Route path="query/results" element={<QueryResults />} />
+                <Route path="query/history" element={<QueryHistory />} />
                 <Route path="settings" element={<Settings />} />
                 <Route path="404" element={<NotFound />} />
                 <Route path="*" element={<Navigate to="/404" replace />} />


### PR DESCRIPTION
## Summary
- add QueryHistory page to view past queries
- store query results in localStorage
- route `/query/history` and sidebar link

## Testing
- `npm run lint` *(fails: warnings found)*
- `npm run build` *(prints TypeScript help output)*

------
https://chatgpt.com/codex/tasks/task_e_684109e648ec833096879788918a7e22